### PR TITLE
Define `unsafe_convert` methods for `HYPRE(Matrix|Vector|Solver)`

### DIFF
--- a/docs/src/libhypre.md
+++ b/docs/src/libhypre.md
@@ -15,15 +15,13 @@ directly.
 Functions from the `LibHYPRE` submodule can be used together with the high level interface.
 This is useful when you need some functionality from the library which isn't exposed in the
 high level interface. Many functions require passing a reference to a matrix/vector or a
-solver. These can be obtained as follows:
-
-| C type signature     | Argument to pass                     |
-|:---------------------|:-------------------------------------|
-| `HYPRE_IJMatrix`     | `A.ijmatrix`  where `A::HYPREMatrix` |
-| `HYPRE_ParCSRMatrix` | `A.parmatrix` where `A::HYPREMatrix` |
-| `HYPRE_IJVector`     | `b.ijvector`  where `b::HYPREVector` |
-| `HYPRE_ParVector`    | `b.parvector` where `b::HYPREVector` |
-| `HYPRE_Solver`       | `s.solver`    where `s::HYPRESolver` |
+solver. HYPRE.jl defines the appropriate conversion methods used by `ccall` such that
+ - `A::HYPREMatrix` can be passed to `HYPRE_*` functions with `HYPRE_IJMatrix` or
+   `HYPRE_ParCSRMatrix` in the signature
+ - `b::HYPREVector` can be passed to `HYPRE_*` functions with `HYPRE_IJVector` or
+   `HYPRE_ParVector` in the signature
+ - `s::HYPRESolver` can be passed to `HYPRE_*` functions with `HYPRE_Solver` in the
+   signature
 
 [^1]: Bindings are generated using
       [Clang.jl](https://github.com/JuliaInterop/Clang.jl), see

--- a/gen/solver_options.jl
+++ b/gen/solver_options.jl
@@ -2,8 +2,7 @@ using HYPRE.LibHYPRE
 
 function generate_options(io, structname, prefixes...)
     println(io, "")
-    println(io, "function Internals.set_options(s::$(structname), kwargs)")
-    println(io, "    solver = s.solver")
+    println(io, "function Internals.set_options(solver::$(structname), kwargs)")
     println(io, "    for (k, v) in kwargs")
 
     ns = Tuple{Symbol,String}[]
@@ -29,7 +28,7 @@ function generate_options(io, structname, prefixes...)
         println(io)
         if k == "Precond"
             println(io, "            Internals.set_precond_defaults(v)")
-            println(io, "            Internals.set_precond(s, v)")
+            println(io, "            Internals.set_precond(solver, v)")
         elseif nargs == 1
             println(io, "            @check ", n, "(solver)")
         elseif nargs == 2

--- a/src/solver_options.jl
+++ b/src/solver_options.jl
@@ -4,8 +4,7 @@
 
 Internals.set_options(::HYPRESolver, kwargs) = nothing
 
-function Internals.set_options(s::BiCGSTAB, kwargs)
-    solver = s.solver
+function Internals.set_options(solver::BiCGSTAB, kwargs)
     for (k, v) in kwargs
         if k === :ConvergenceFactorTol
             @check HYPRE_BiCGSTABSetConvergenceFactorTol(solver, v)
@@ -19,7 +18,7 @@ function Internals.set_options(s::BiCGSTAB, kwargs)
             @check HYPRE_ParCSRBiCGSTABSetMinIter(solver, v)
         elseif k === :Precond
             Internals.set_precond_defaults(v)
-            Internals.set_precond(s, v)
+            Internals.set_precond(solver, v)
         elseif k === :PrintLevel
             @check HYPRE_ParCSRBiCGSTABSetPrintLevel(solver, v)
         elseif k === :StopCrit
@@ -32,8 +31,7 @@ function Internals.set_options(s::BiCGSTAB, kwargs)
     end
 end
 
-function Internals.set_options(s::BoomerAMG, kwargs)
-    solver = s.solver
+function Internals.set_options(solver::BoomerAMG, kwargs)
     for (k, v) in kwargs
         if k === :ADropTol
             @check HYPRE_BoomerAMGSetADropTol(solver, v)
@@ -289,8 +287,7 @@ function Internals.set_options(s::BoomerAMG, kwargs)
     end
 end
 
-function Internals.set_options(s::FlexGMRES, kwargs)
-    solver = s.solver
+function Internals.set_options(solver::FlexGMRES, kwargs)
     for (k, v) in kwargs
         if k === :ConvergenceFactorTol
             @check HYPRE_FlexGMRESSetConvergenceFactorTol(solver, v)
@@ -308,7 +305,7 @@ function Internals.set_options(s::FlexGMRES, kwargs)
             @check HYPRE_ParCSRFlexGMRESSetModifyPC(solver, v)
         elseif k === :Precond
             Internals.set_precond_defaults(v)
-            Internals.set_precond(s, v)
+            Internals.set_precond(solver, v)
         elseif k === :PrintLevel
             @check HYPRE_ParCSRFlexGMRESSetPrintLevel(solver, v)
         elseif k === :Tol
@@ -319,8 +316,7 @@ function Internals.set_options(s::FlexGMRES, kwargs)
     end
 end
 
-function Internals.set_options(s::GMRES, kwargs)
-    solver = s.solver
+function Internals.set_options(solver::GMRES, kwargs)
     for (k, v) in kwargs
         if k === :ConvergenceFactorTol
             @check HYPRE_GMRESSetConvergenceFactorTol(solver, v)
@@ -340,7 +336,7 @@ function Internals.set_options(s::GMRES, kwargs)
             @check HYPRE_ParCSRGMRESSetMinIter(solver, v)
         elseif k === :Precond
             Internals.set_precond_defaults(v)
-            Internals.set_precond(s, v)
+            Internals.set_precond(solver, v)
         elseif k === :PrintLevel
             @check HYPRE_ParCSRGMRESSetPrintLevel(solver, v)
         elseif k === :StopCrit
@@ -353,8 +349,7 @@ function Internals.set_options(s::GMRES, kwargs)
     end
 end
 
-function Internals.set_options(s::Hybrid, kwargs)
-    solver = s.solver
+function Internals.set_options(solver::Hybrid, kwargs)
     for (k, v) in kwargs
         if k === :AbsoluteTol
             @check HYPRE_ParCSRHybridSetAbsoluteTol(solver, v)
@@ -424,7 +419,7 @@ function Internals.set_options(s::Hybrid, kwargs)
             @check HYPRE_ParCSRHybridSetPMaxElmts(solver, v)
         elseif k === :Precond
             Internals.set_precond_defaults(v)
-            Internals.set_precond(s, v)
+            Internals.set_precond(solver, v)
         elseif k === :PrintLevel
             @check HYPRE_ParCSRHybridSetPrintLevel(solver, v)
         elseif k === :RecomputeResidual
@@ -463,8 +458,7 @@ function Internals.set_options(s::Hybrid, kwargs)
     end
 end
 
-function Internals.set_options(s::ILU, kwargs)
-    solver = s.solver
+function Internals.set_options(solver::ILU, kwargs)
     for (k, v) in kwargs
         if k === :DropThreshold
             @check HYPRE_ILUSetDropThreshold(solver, v)
@@ -498,8 +492,7 @@ function Internals.set_options(s::ILU, kwargs)
     end
 end
 
-function Internals.set_options(s::ParaSails, kwargs)
-    solver = s.solver
+function Internals.set_options(solver::ParaSails, kwargs)
     for (k, v) in kwargs
         if k === :Filter
             @check HYPRE_ParCSRParaSailsSetFilter(solver, v)
@@ -519,8 +512,7 @@ function Internals.set_options(s::ParaSails, kwargs)
     end
 end
 
-function Internals.set_options(s::PCG, kwargs)
-    solver = s.solver
+function Internals.set_options(solver::PCG, kwargs)
     for (k, v) in kwargs
         if k === :AbsoluteTolFactor
             @check HYPRE_PCGSetAbsoluteTolFactor(solver, v)
@@ -540,7 +532,7 @@ function Internals.set_options(s::PCG, kwargs)
             @check HYPRE_ParCSRPCGSetMaxIter(solver, v)
         elseif k === :Precond
             Internals.set_precond_defaults(v)
-            Internals.set_precond(s, v)
+            Internals.set_precond(solver, v)
         elseif k === :PrintLevel
             @check HYPRE_ParCSRPCGSetPrintLevel(solver, v)
         elseif k === :RelChange


### PR DESCRIPTION
This patch adds methods for `Base.unsafe_convert` for `HYPREMatrix`, `HYPREVector`, and `HYPRESolver`. This means that those objects can be passed directly to `ccall` and be "converted" (i.e. extracting the pointer that is stored in the structs) to the appropriate type expected by the HYPRE C-library. The advantage is that `ccall` then guarantees that the objects are kept alive for the duration of the call.