### PR TITLE
Add compat for HYPRE_jll + bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "HYPRE"
 uuid = "b5ffcf37-a2bd-41ab-a3da-4bd9bc8ad771"
-version = "1.7.0"
+version = "1.7.1"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -22,6 +22,7 @@ HYPRESparseMatricesCSR = ["SparseArrays", "SparseMatricesCSR"]
 CEnum = "0.4, 0.5"
 MPI = "0.19, 0.20"
 PartitionedArrays = "0.5"
+HYPRE_jll = "2"
 SparseMatricesCSR = "0.6"
 julia = "1.10"
 


### PR DESCRIPTION
This would avoid that HYPRE.jl makes use of the breaking JLL until we have an update: https://github.com/JuliaPackaging/Yggdrasil/pull/12254